### PR TITLE
Add Github OIDC provider module

### DIFF
--- a/github_oidc_provider/README.md
+++ b/github_oidc_provider/README.md
@@ -1,0 +1,25 @@
+# Github OpenID Connect Provider
+
+This module creates an OpenID Connect provider which allows Github Tokens to authenticate via the assume role mechanism. The module's input is a map of repository names and the role policy ARN to associate with the given repository.
+
+## Example
+
+In this example, an OpenID Connect provider resource is created with GitHub's public key thumbprint and policy documents for each repository are created. The policy document should be the service's assertion of the minimal permissions needed for GitHub automated workflows.
+
+```
+module "GitHubOIDC" {
+    source = "git@github.com:starframe-systems/tf-stencils.git//github_oidc_provider?ref=v0.1.0"
+
+    iam_role_policy_map = {
+        "organization/user-service" = module.UserService.iam_policy_arn['oidc_deploy']
+        "organization/transaction-service" = module.TransactionService.iam_policy_arn['oidc_deploy']
+    }
+}
+```
+
+## Variables
+
+**`iam_role_policy_map`**
+
+- **Description:** A map of GitHub repository names to IAM Policy ARNs
+- **Type:** `map(string, string)`

--- a/github_oidc_provider/README.md
+++ b/github_oidc_provider/README.md
@@ -22,4 +22,4 @@ module "GitHubOIDC" {
 **`iam_role_policy_map`**
 
 - **Description:** A map of GitHub repository names to IAM Policy ARNs
-- **Type:** `map(string, string)`
+- **Type:** `map(string)`

--- a/github_oidc_provider/aws_iam_openid_connect_provider.tf
+++ b/github_oidc_provider/aws_iam_openid_connect_provider.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_openid_connect_provider" "this" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  # To calculate the (finger|thumb)print:
+  # $ OID_URL='https://token.actions.githubusercontent.com/.well-known/openid-configuration'
+  # $ HOST=$(curl $OID_URL \
+  #   | jq -r '.jwks_uri | split("/")[2]')
+  # $ echo | openssl s_client -servername $HOST -showcerts -connect $HOST:443 2> /dev/null \
+  #   | sed -n -e '/BEGIN/h' -e '/BEGIN/,/END/H' -e '$x' -e '$p' | tail +2 \
+  #   | openssl x509 -fingerprint -noout \
+  #   | sed -e "s/.*=//" -e "s/://g" | tr "ABCDEF" "abcdef"
+  thumbprint_list = [
+    "d89e3bd43d5d909b47a18977aa9d5ce36cee184c",
+    "2b18947a6a9fc7764fd8b5fb18a863b0c6dac24f", # Generated 2025-07-30
+  ]
+}

--- a/github_oidc_provider/aws_iam_openid_connect_provider.tf
+++ b/github_oidc_provider/aws_iam_openid_connect_provider.tf
@@ -3,10 +3,10 @@ locals {
 }
 
 data "external" "thumbprint" {
-  program = ["bin/thumbprint.sh", local.openid_url]
+  program = ["${path.module}/bin/thumbprint.sh", local.openid_url]
 }
 
-resource "aws_iam_openid_connect_provider" "this" {
+resource "aws_iam_openid_connect_provider" "default" {
   url = "https://token.actions.githubusercontent.com"
 
   client_id_list = [

--- a/github_oidc_provider/aws_iam_openid_connect_provider.tf
+++ b/github_oidc_provider/aws_iam_openid_connect_provider.tf
@@ -1,3 +1,11 @@
+locals {
+  openid_url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+data "external" "thumbprint" {
+  program = ["bin/thumbprint.sh", local.openid_url]
+}
+
 resource "aws_iam_openid_connect_provider" "this" {
   url = "https://token.actions.githubusercontent.com"
 
@@ -5,16 +13,5 @@ resource "aws_iam_openid_connect_provider" "this" {
     "sts.amazonaws.com",
   ]
 
-  # To calculate the (finger|thumb)print:
-  # $ OID_URL='https://token.actions.githubusercontent.com/.well-known/openid-configuration'
-  # $ HOST=$(curl $OID_URL \
-  #   | jq -r '.jwks_uri | split("/")[2]')
-  # $ echo | openssl s_client -servername $HOST -showcerts -connect $HOST:443 2> /dev/null \
-  #   | sed -n -e '/BEGIN/h' -e '/BEGIN/,/END/H' -e '$x' -e '$p' | tail +2 \
-  #   | openssl x509 -fingerprint -noout \
-  #   | sed -e "s/.*=//" -e "s/://g" | tr "ABCDEF" "abcdef"
-  thumbprint_list = [
-    "d89e3bd43d5d909b47a18977aa9d5ce36cee184c",
-    "2b18947a6a9fc7764fd8b5fb18a863b0c6dac24f", # Generated 2025-07-30
-  ]
+  thumbprint_list = [data.external.thumbprint.result.thumbprint]
 }

--- a/github_oidc_provider/aws_iam_role.tf
+++ b/github_oidc_provider/aws_iam_role.tf
@@ -28,8 +28,8 @@ data "aws_iam_policy_document" "default" {
 resource "aws_iam_role" "default" {
   for_each = data.aws_iam_policy_document.default
 
-  name                 = "${each.key}-GithubOidcRolePolicy"
-  description          = "Deploy access for Github Actions on authorized repositories"
+  name                 = replace("${each.key}-GithubOidcRolePolicy", "/", "-")
+  description          = "Deploy access for Github Actions on ${each.key}"
   max_session_duration = 3600 # 1h
   assume_role_policy   = each.value.json
 }

--- a/github_oidc_provider/aws_iam_role.tf
+++ b/github_oidc_provider/aws_iam_role.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "default" {
+  for_each = var.iam_role_policy_map
+
+  statement {
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.default.id]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${each.key}:*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "default" {
+  for_each = data.aws_iam_policy_document.default
+
+  name                 = "${each.key}-GithubOidcRolePolicy"
+  description          = "Deploy access for Github Actions on authorized repositories"
+  max_session_duration = 3600 # 1h
+  assume_role_policy   = each.value.json
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  for_each = aws_iam_role.default
+
+  role       = each.value.name
+  policy_arn = var.iam_role_policy_map[each.key]
+}

--- a/github_oidc_provider/bin/thumbprint.sh
+++ b/github_oidc_provider/bin/thumbprint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+HOST=$(curl $1 | jq -r '.jwks_uri | split("/")[2]')
+
+THUMBPRINT=$(echo | openssl s_client -servername $HOST -showcerts -connect $HOST:443 2> /dev/null \
+    | sed -n -e '/BEGIN/h' -e '/BEGIN/,/END/H' -e '$x' -e '$p' | tail +2 \
+    | openssl x509 -fingerprint -noout \
+    | sed -e "s/.*=//" -e "s/://g" | tr "ABCDEF" "abcdef")
+
+THUMBPRINT_JSON="{\"thumbprint\": \"${THUMBPRINT}\"}"
+echo $THUMBPRINT_JSON

--- a/github_oidc_provider/variables.tf
+++ b/github_oidc_provider/variables.tf
@@ -1,6 +1,6 @@
 
 variable "iam_role_policy_map" {
   description = "Map of repository names to policy ARNs"
-  type        = map(string, string)
+  type        = map(string)
   default     = {}
 }

--- a/github_oidc_provider/variables.tf
+++ b/github_oidc_provider/variables.tf
@@ -1,0 +1,6 @@
+
+variable "iam_role_policy_map" {
+  description = "Map of repository names to policy ARNs"
+  type        = map(string, string)
+  default     = {}
+}


### PR DESCRIPTION
Terraform module to create the Github OIDC provider in AWS and allow attachment of policies for automated deployment via GitHub Token authorization