### PR TITLE
Revert key_schema block

### DIFF
--- a/dynamo_db/ddb_table.tf
+++ b/dynamo_db/ddb_table.tf
@@ -33,11 +33,8 @@ resource "aws_dynamodb_table" "this" {
   dynamic "global_secondary_index" {
     for_each = var.global_secondary_indexes
     content {
-      name = global_secondary_index.value.name
-      key_schema {
-        attribute_name = global_secondary_index.value.hash_key
-        key_type       = "HASH"
-      }
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key
       projection_type    = global_secondary_index.value.projection_type
       non_key_attributes = global_secondary_index.value.non_key_attributes
       read_capacity      = global_secondary_index.value.read_capacity


### PR DESCRIPTION
The `key_schema` block was added to the Global Secondary Index block in the DDB Table resource because VS Code warned that the `hash_key` property was deprecated. The installed version of Terraform on some projects doesn't (yet?) support `key_schema` blocks, so the change needed to be backed out.